### PR TITLE
Add companies as standalone section and page

### DIFF
--- a/content/companies/_index.md
+++ b/content/companies/_index.md
@@ -1,0 +1,3 @@
+---
+title: "GitHub Companies"
+---

--- a/content/organizations/_index.md
+++ b/content/organizations/_index.md
@@ -1,3 +1,3 @@
 ---
-title: "GitHub Organizations (Companies or Projects)"
+title: "GitHub Organizations"
 ---


### PR DESCRIPTION
This is to add companies as standalone section and page to the site. It was partially discussed in #18 and added in opensourcecities/osc-theme#12.

Partially_Fixes #18 